### PR TITLE
feat: Enhance ChatGPT integration, add sidebar settings & refactor CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ https://github.com/user-attachments/assets/a069a178-631e-4b35-a182-9f4fef7735c4
 3. Start chatting with any supported AI assistant
 4. For ChatGPT and Perplexity, just press enter while chatting as you would normally
 5. On Claude, click the Mem0 button or use shortcut ^ + M
+6. For ChatGPT, you can now also use the dedicated Mem0 button (icon) next to the message input area to fetch and inject relevant memories before you send your message. This gives you a chance to review the memories. The Enter key will still work as before (if enabled in settings).
+
+*[Note: Screenshots to be updated to reflect new UI elements.]*
+
+## Settings
+
+You can access settings via the ellipsis (...) menu in the Mem0 sidebar.
+
+### API Key Management
+In the Settings panel, you can view and update your Mem0 API key. If you need to change your key, enter the new one and click 'Save'.
+
+### Preferences
+- **Enter-Key for Memory (ChatGPT):** A new preference allows you to control whether pressing the Enter key in ChatGPT automatically retrieves and injects memories. This is enabled by default. You can toggle this behavior in the Settings panel. The Enter-key behavior for Perplexity and other platforms remains unchanged.
 
 ## ❤️ Free to Use
 
@@ -54,8 +67,12 @@ Mem0 is completely free with:
 
 ## Configuration
 
-- API Key: Required for connecting to the Mem0 API. Obtain this from your Mem0 Dashboard.
-- User ID: Your unique identifier in the Mem0 system. If not provided, it defaults to 'chrome-extension-user'.
+The primary configuration, such as setting your API Key and managing preferences, is now done through the Settings panel in the Mem0 sidebar.
+
+- **API Key:** Required for connecting to the Mem0 API. Obtain this from your Mem0 Dashboard and enter it in the sidebar settings.
+- **User ID:** Your unique identifier in the Mem0 system. This is typically handled automatically upon login.
+- **Enter-Key Interception (ChatGPT):** Toggle this feature in the sidebar settings as described above.
+
 
 ## Troubleshooting
 

--- a/chatgpt/content.js
+++ b/chatgpt/content.js
@@ -3,135 +3,185 @@ let isProcessingMem0 = false;
 // Initialize the MutationObserver variable
 let observer;
 
-// function createPopup(container) {
-//   const popup = document.createElement("div");
-//   popup.className = "mem0-popup";
-//   popup.style.cssText = `
-//         display: none;
-//         position: absolute;
-//         background-color: #171717;
-//         color: white;
-//         padding: 6px 8px;
-//         border-radius: 6px;
-//         font-size: 12px;
-//         z-index: 10000;
-//         bottom: 100%;
-//         left: 50%;
-//         transform: translateX(-50%);
-//         margin-bottom: 11px;
-//         white-space: nowrap;
-//         box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-//     `;
-//   container.appendChild(popup);
-//   return popup;
-// }
+function createPopup(container) {
+  const popup = document.createElement("div");
+  popup.className = "mem0-popup";
+  popup.style.cssText = `
+        display: none;
+        position: absolute;
+        background-color: #171717;
+        color: white;
+        padding: 6px 8px;
+        border-radius: 6px;
+        font-size: 12px;
+        z-index: 10000;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        margin-bottom: 11px;
+        white-space: nowrap;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    `;
+  container.appendChild(popup);
+  return popup;
+}
 
-// function addMem0Button() {
-//   const sendButton = document.querySelector('button[aria-label="Send prompt"]');
+function addMem0Button() {
+  const textArea = document.querySelector("textarea#prompt-textarea");
+  if (!textArea) return;
 
-//   if (sendButton && !document.querySelector("#mem0-button")) {
-//     const sendButtonContainer = sendButton.parentElement.parentElement;
+  const sendButton = textArea.parentElement.querySelector('button[data-testid="send-button"]');
 
-//     const mem0ButtonContainer = document.createElement("div");
-//     mem0ButtonContainer.style.position = "relative";
-//     mem0ButtonContainer.style.display = "inline-block";
+  if (sendButton && !document.querySelector("#mem0-button")) {
+    const mem0ButtonContainer = document.createElement("div");
+    mem0ButtonContainer.style.position = "relative";
+    mem0ButtonContainer.style.display = "flex";
+    mem0ButtonContainer.style.alignItems = "center";
+    mem0ButtonContainer.style.marginRight = "8px";
 
-//     const mem0Button = document.createElement("img");
-//     mem0Button.id = "mem0-button";
-//     mem0Button.src = chrome.runtime.getURL("icons/mem0-claude-icon-purple.png");
-//     mem0Button.style.width = "20px";
-//     mem0Button.style.height = "20px";
-//     mem0Button.style.cursor = "pointer";
-//     mem0Button.style.padding = "8px";
-//     mem0Button.style.borderRadius = "5px";
-//     mem0Button.style.transition = "filter 0.3s ease, opacity 0.3s ease";
-//     mem0Button.style.boxSizing = "content-box";
-//     mem0Button.style.marginBottom = "1px";
+    const mem0Button = document.createElement("button");
+    mem0Button.id = "mem0-button";
+    mem0Button.type = "button";
+    mem0Button.style.background = "none";
+    mem0Button.style.border = "none";
+    mem0Button.style.padding = "0";
+    mem0Button.style.margin = "0";
+    mem0Button.style.cursor = "pointer";
+    mem0Button.style.display = "flex";
+    mem0Button.style.alignItems = "center";
+    mem0Button.style.justifyContent = "center";
+    mem0Button.style.width = "38px";
+    mem0Button.style.height = "38px";
+    mem0Button.style.borderRadius = "5px";
+    mem0Button.style.transition = "background-color 0.2s ease, opacity 0.3s ease";
 
-//     const popup = createPopup(mem0ButtonContainer);
+    const icon = document.createElement("img");
+    icon.src = chrome.runtime.getURL("icons/mem0-claude-icon-purple.png");
+    icon.style.width = "20px";
+    icon.style.height = "20px";
+    icon.style.transition = "filter 0.3s ease";
+    mem0Button.appendChild(icon);
 
-//     mem0Button.addEventListener("click", () => handleMem0Click(popup));
+    // const popup = createPopup(mem0ButtonContainer); // Kept if needed for specific messages for this button
 
-//     mem0Button.addEventListener("mouseenter", () => {
-//       if (!mem0Button.disabled) {
-//         mem0Button.style.filter = "brightness(70%)";
-//         tooltip.style.visibility = "visible";
-//         tooltip.style.opacity = "1";
-//       }
-//     });
-//     mem0Button.addEventListener("mouseleave", () => {
-//       mem0Button.style.filter = "none";
-//       tooltip.style.visibility = "hidden";
-//       tooltip.style.opacity = "0";
-//     });
+    mem0Button.addEventListener("click", () => handleMem0Click(false)); // Don't auto-send on button click
 
-//     const tooltip = document.createElement("div");
-//     tooltip.textContent = "Add related memories";
-//     tooltip.style.visibility = "hidden";
-//     tooltip.style.backgroundColor = "black";
-//     tooltip.style.color = "white";
-//     tooltip.style.textAlign = "center";
-//     tooltip.style.borderRadius = "4px";
-//     tooltip.style.padding = "3px 6px";
-//     tooltip.style.position = "absolute";
-//     tooltip.style.zIndex = "1";
-//     tooltip.style.top = "calc(100% + 5px)";
-//     tooltip.style.left = "50%";
-//     tooltip.style.transform = "translateX(-50%)";
-//     tooltip.style.whiteSpace = "nowrap";
-//     tooltip.style.opacity = "0";
-//     tooltip.style.transition = "opacity 0.3s";
-//     tooltip.style.fontSize = "12px";
+    mem0Button.addEventListener("mouseenter", () => {
+      if (!mem0Button.disabled) {
+        mem0Button.style.backgroundColor = "rgba(255, 255, 255, 0.1)";
+        tooltip.style.visibility = "visible";
+        tooltip.style.opacity = "1";
+      }
+    });
+    mem0Button.addEventListener("mouseleave", () => {
+      mem0Button.style.backgroundColor = "transparent";
+      tooltip.style.visibility = "hidden";
+      tooltip.style.opacity = "0";
+    });
 
-//     mem0ButtonContainer.appendChild(mem0Button);
-//     mem0ButtonContainer.appendChild(tooltip);
+    const tooltip = document.createElement("div");
+    tooltip.textContent = "Add related memories (Ctrl+M)";
+    tooltip.style.visibility = "hidden";
+    tooltip.style.backgroundColor = "black";
+    tooltip.style.color = "white";
+    tooltip.style.textAlign = "center";
+    tooltip.style.borderRadius = "4px";
+    tooltip.style.padding = "5px 8px";
+    tooltip.style.position = "absolute";
+    tooltip.style.zIndex = "10001";
+    tooltip.style.bottom = "calc(100% + 8px)";
+    tooltip.style.left = "50%";
+    tooltip.style.transform = "translateX(-50%)";
+    tooltip.style.whiteSpace = "nowrap";
+    tooltip.style.opacity = "0";
+    tooltip.style.transition = "opacity 0.2s ease, visibility 0.2s ease";
+    tooltip.style.fontSize = "12px";
 
-//     // Insert the mem0Button before the sendButton
-//     sendButtonContainer.insertBefore(
-//       mem0ButtonContainer,
-//       sendButtonContainer.children[1]
-//     );
+    mem0ButtonContainer.appendChild(mem0Button);
+    mem0ButtonContainer.appendChild(tooltip);
 
-//     // Function to update button states
-//     function updateButtonStates() {
-//       const inputElement =
-//         document.querySelector('div[contenteditable="true"]') ||
-//         document.querySelector("textarea");
-//       const hasText =
-//         inputElement && inputElement.textContent.trim().length > 0;
+    const sendButtonWrapper = sendButton.parentNode;
+    if (sendButtonWrapper) {
+      sendButtonWrapper.insertBefore(mem0ButtonContainer, sendButton);
+    }
 
-//       mem0Button.disabled = !hasText;
+    function updateButtonStates() {
+      const currentInputElement = document.querySelector("textarea#prompt-textarea");
+      const hasText = currentInputElement && currentInputElement.value.trim().length > 0;
+      mem0Button.disabled = !hasText;
+      mem0Button.style.opacity = hasText ? "1" : "0.5";
+      mem0Button.style.pointerEvents = hasText ? "auto" : "none";
+    }
 
-//       if (hasText) {
-//         mem0Button.style.opacity = "1";
-//         mem0Button.style.pointerEvents = "auto";
-//       } else {
-//         mem0Button.style.opacity = "0.5";
-//         mem0Button.style.pointerEvents = "none";
-//       }
-//     }
+    updateButtonStates();
+    const currentInputElement = document.querySelector("textarea#prompt-textarea");
+    if (currentInputElement) {
+      currentInputElement.addEventListener("input", updateButtonStates);
+    }
+  }
+}
 
-//     // Initial update
-//     updateButtonStates();
+// New function for toast-like notifications
+function showToastNotification(message, type = "info") {
+  const toastId = "mem0-toast-notification";
+  // Remove existing toast if any
+  const existingToast = document.getElementById(toastId);
+  if (existingToast) {
+    existingToast.remove();
+  }
 
-//     // Listen for input changes
-//     const inputElement =
-//       document.querySelector('div[contenteditable="true"]') ||
-//       document.querySelector("textarea");
-//     if (inputElement) {
-//       inputElement.addEventListener("input", updateButtonStates);
-//     }
-//   }
-// }
+  const toast = document.createElement("div");
+  toast.id = toastId;
+  toast.className = `mem0-toast mem0-toast-${type}`;
+  toast.textContent = message;
+
+  toast.style.position = "fixed";
+  toast.style.bottom = "20px";
+  toast.style.left = "50%";
+  toast.style.transform = "translateX(-50%)";
+  toast.style.padding = "12px 20px";
+  toast.style.borderRadius = "6px";
+  toast.style.color = "white";
+  toast.style.zIndex = "20000";
+  toast.style.fontSize = "14px";
+  toast.style.boxShadow = "0 4px 10px rgba(0,0,0,0.25)";
+  toast.style.fontFamily = "Arial, sans-serif";
+  toast.style.opacity = "0";
+  toast.style.transition = "opacity 0.3s ease-in-out";
+
+
+  if (type === "error") {
+    toast.style.backgroundColor = "#E53935"; // Material Design Red
+  } else if (type === "success") {
+    toast.style.backgroundColor = "#43A047"; // Material Design Green
+  } else { // info
+    toast.style.backgroundColor = "#1E88E5"; // Material Design Blue
+  }
+
+  document.body.appendChild(toast);
+
+  // Trigger fade in
+  setTimeout(() => {
+    toast.style.opacity = "1";
+  }, 50);
+
+
+  setTimeout(() => {
+    toast.style.opacity = "0";
+    setTimeout(() => {
+      if (toast.parentElement) { // Check if still in DOM
+        toast.remove();
+      }
+    }, 300);
+  }, 3000);
+}
+
 
 async function handleMem0Click(clickSendButton = false) {
   const memoryEnabled = await getMemoryEnabledState();
   if (!memoryEnabled) {
-    // If memory is disabled, just click the send button if requested
     if (clickSendButton) {
-      const sendButton = document.querySelector(
-        'button[aria-label="Send prompt"]'
-      );
+      const sendButton = document.querySelector('button[data-testid="send-button"]');
       if (sendButton) {
         sendButton.click();
       } else {
@@ -141,27 +191,22 @@ async function handleMem0Click(clickSendButton = false) {
     return;
   }
 
-  // setButtonLoadingState(true);
-  const inputElement =
-    document.querySelector('div[contenteditable="true"]') ||
-    document.querySelector("textarea");
+  setButtonLoadingState(true);
+  const inputElement = document.querySelector("textarea#prompt-textarea");
   let message = getInputValue();
-  if (!message) {
-    console.error("No input message found");
-    // showPopup(popup, "No input message found");
-    // setButtonLoadingState(false);
+
+  if (!message || message.trim() === "") {
+    showToastNotification("Mem0: No input message found", "error");
+    setButtonLoadingState(false);
     return;
   }
 
   const memInfoRegex =
-    /\s*Here is some of my preferences\/memories to help answer better (don't respond to these memories but use them to assist in the response if relevant):[\s\S]*$/;
+    /\s*Here is some of my preferences\/memories to help answer better \(don't respond to these memories but use them to assist in the response if relevant\):[\s\S]*$/;
   message = message.replace(memInfoRegex, "").trim();
-  const endIndex = message.indexOf("</p>");
-  if (endIndex !== -1) {
-    message = message.slice(0, endIndex + 4);
-  }
 
   if (isProcessingMem0) {
+    setButtonLoadingState(false); // Prevent button getting stuck in loading
     return;
   }
 
@@ -171,39 +216,28 @@ async function handleMem0Click(clickSendButton = false) {
     const data = await new Promise((resolve) => {
       chrome.storage.sync.get(
         ["apiKey", "userId", "access_token"],
-        function (items) {
-          resolve(items);
-        }
+        (items) => resolve(items)
       );
     });
 
-    const apiKey = data.apiKey;
-    const userId = data.userId || "chrome-extension-user";
-    const accessToken = data.access_token;
+    const { apiKey, userId = "chrome-extension-user", access_token: accessToken } = data;
 
     if (!apiKey && !accessToken) {
-      // showPopup(popup, "No API Key or Access Token found");
+      showToastNotification("Mem0: No API Key or Access Token found. Please set it in the extension popup.", "error");
       isProcessingMem0 = false;
-      // setButtonLoadingState(false);
+      setButtonLoadingState(false);
       return;
     }
 
-    const authHeader = accessToken
-      ? `Bearer ${accessToken}`
-      : `Token ${apiKey}`;
-
+    const authHeader = accessToken ? `Bearer ${accessToken}` : `Token ${apiKey}`;
     const messages = getLastMessages(2);
     messages.push({ role: "user", content: message });
 
-    // Existing search API call
     const searchResponse = await fetch(
       "https://api.mem0.ai/v1/memories/search/",
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: authHeader,
-        },
+        headers: { "Content-Type": "application/json", Authorization: authHeader },
         body: JSON.stringify({
           query: message,
           user_id: userId,
@@ -216,99 +250,66 @@ async function handleMem0Click(clickSendButton = false) {
     );
 
     if (!searchResponse.ok) {
-      throw new Error(
-        `API request failed with status ${searchResponse.status}`
-      );
+      showToastNotification(`Mem0: Error processing memories (Code: ${searchResponse.status})`, "error");
+      throw new Error(`API request failed with status ${searchResponse.status}`);
     }
 
     const responseData = await searchResponse.json();
 
     if (inputElement) {
       const memories = responseData.map((item) => item.memory);
-      const providers = responseData.map((item) =>
-        item.metadata && item.metadata.provider ? item.metadata.provider : ""
-      );
 
       if (memories.length > 0) {
-        let currentContent =
-          inputElement.tagName.toLowerCase() === "div"
-            ? inputElement.innerHTML
-            : inputElement.value;
-
-        const memInfoRegex =
-          /\s*Here is some of my preferences\/memories to help answer better (don't respond to these memories but use them to assist in the response if relevant):[\s\S]*$/;
+        let currentContent = inputElement.value;
         currentContent = currentContent.replace(memInfoRegex, "").trim();
-        const lastParagraphRegex =
-          /<p><br class="ProseMirror-trailingBreak"><\/p><p>$/;
-        currentContent = currentContent.replace(lastParagraphRegex, "").trim();
 
-        let memoriesContent =
-          '<div id="mem0-wrapper" style="background-color: rgb(220, 252, 231); padding: 8px; border-radius: 4px; margin-top: 8px; margin-bottom: 8px;">';
-        memoriesContent +=
-          "<strong>Here is some of my preferences/memories to help answer better (don't respond to these memories but use them to assist in the response if relevant):</strong>";
+        let memoriesText = "\n\nHere is some of my preferences/memories to help answer better (don't respond to these memories but use them to assist in the response if relevant):\n";
         memories.forEach((mem) => {
-          memoriesContent += `<div>- ${mem}</div>`;
+          memoriesText += `- ${mem}\n`;
         });
-        memoriesContent += "</div>";
 
-        if (inputElement.tagName.toLowerCase() === "div") {
-          inputElement.innerHTML = `${currentContent}<div><br></div>${memoriesContent}`;
-        } else {
-          inputElement.value = `${currentContent}\n${memoriesContent}`;
-        }
+        inputElement.value = `${currentContent}${memoriesText}`;
         inputElement.dispatchEvent(new Event("input", { bubbles: true }));
+        inputElement.style.height = 'auto';
+        inputElement.style.height = (inputElement.scrollHeight) + 'px';
+        showToastNotification("Mem0: Memories injected.", "success");
       } else {
-        if (inputElement.tagName.toLowerCase() === "div") {
-          inputElement.innerHTML = message;
-        } else {
-          inputElement.value = message;
-        }
+        inputElement.value = message;
         inputElement.dispatchEvent(new Event("input", { bubbles: true }));
-        // showPopup(popup, "No memories found");
+        showToastNotification("Mem0: No relevant memories found.");
       }
     } else {
-      // showPopup(popup, "No input field found to update");
+      showToastNotification("Mem0: Input field not found.", "error");
     }
 
-    // setButtonLoadingState(false);
-
     if (clickSendButton) {
-      const sendButton = document.querySelector(
-        'button[aria-label="Send prompt"]'
-      );
+      const sendButton = document.querySelector('button[data-testid="send-button"]');
       if (sendButton) {
         setTimeout(() => {
           sendButton.click();
         }, 100);
       } else {
-        console.error("Send button not found");
+        console.error("Send button not found for auto-click");
       }
     }
 
-    // Proceed with adding memory asynchronously without awaiting
     fetch("https://api.mem0.ai/v1/memories/", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: authHeader,
-      },
+      headers: { "Content-Type": "application/json", Authorization: authHeader },
       body: JSON.stringify({
-        messages: messages,
+        messages,
         user_id: userId,
         infer: true,
-        metadata: {
-          provider: "ChatGPT",
-        },
+        metadata: { provider: "ChatGPT" },
       }),
-    }).catch((error) => {
-      console.error("Error adding memory:", error);
-    });
+    }).catch((error) => console.error("Error adding memory:", error));
+
   } catch (error) {
-    console.error("Error:", error);
-    // setButtonLoadingState(false);
-    throw error; // Rethrow the error to be caught in the calling function
+    console.error("Error in handleMem0Click:", error);
+    showToastNotification("Mem0: An unexpected error occurred.", "error");
   } finally {
     isProcessingMem0 = false;
+    setButtonLoadingState(false); // Ensure loading state is always reset
   }
 }
 
@@ -348,7 +349,6 @@ function getLastMessages(count) {
 }
 
 function showPopup(popup, message) {
-  // Create and add the (i) icon
   const infoIcon = document.createElement("span");
   infoIcon.textContent = "ⓘ ";
   infoIcon.style.marginRight = "3px";
@@ -360,31 +360,50 @@ function showPopup(popup, message) {
   popup.style.display = "block";
   setTimeout(() => {
     popup.style.display = "none";
-  }, 2000);
+  }, 3000);
 }
 
 function setButtonLoadingState(isLoading) {
   const mem0Button = document.querySelector("#mem0-button");
   if (mem0Button) {
+    const icon = mem0Button.querySelector("img");
     if (isLoading) {
       mem0Button.disabled = true;
-      document.body.style.cursor = "wait";
-      mem0Button.style.cursor = "wait";
       mem0Button.style.opacity = "0.7";
+      if (icon) {
+        icon.src = chrome.runtime.getURL("icons/loader.svg");
+        icon.style.animation = "spin 1s linear infinite";
+      }
     } else {
       mem0Button.disabled = false;
-      document.body.style.cursor = "default";
-      mem0Button.style.cursor = "pointer";
       mem0Button.style.opacity = "1";
+      if (icon) {
+        icon.src = chrome.runtime.getURL("icons/mem0-claude-icon-purple.png");
+        icon.style.animation = "none";
+      }
     }
   }
 }
 
+function ensureSpinAnimation() {
+    if (!document.getElementById('mem0-spin-animation')) {
+        const style = document.createElement('style');
+        style.id = 'mem0-spin-animation';
+        style.textContent = `
+            @keyframes spin {
+                0% { transform: rotate(0deg); }
+                100% { transform: rotate(360deg); }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+}
+ensureSpinAnimation();
+
+
 function getInputValue() {
-  const inputElement =
-    document.querySelector('div[contenteditable="true"]') ||
-    document.querySelector("textarea");
-  return inputElement ? inputElement.textContent || inputElement.value : null;
+  const inputElement = document.querySelector("textarea#prompt-textarea");
+  return inputElement ? inputElement.value : null;
 }
 
 function addSyncButton() {
@@ -664,92 +683,92 @@ function sendMemoryToMem0(memory) {
   });
 }
 
-function initializeMem0Integration() {
-  document.addEventListener("DOMContentLoaded", () => {
-    // addMem0Button();
-    addSyncButton();
-    addEnterKeyInterception();
-  });
-
-  document.addEventListener("keydown", function (event) {
-    if (event.ctrlKey && event.key === "m") {
-      event.preventDefault();
-      (async () => {
-        await handleMem0Click(true);
-      })();
-    }
-  });
+function observeDOMChanges() {
+  if (observer) observer.disconnect();
 
   observer = new MutationObserver(() => {
-    // addMem0Button();
-    addSyncButton();
+      addMem0Button();
+      addSyncButton();
+      addEnterKeyInterception();
   });
 
   observer.observe(document.body, { childList: true, subtree: true });
+}
 
-  // Add a MutationObserver to watch for changes in the DOM
-  const observerForEnterKey = new MutationObserver(() => {
-    addEnterKeyInterception();
-  });
+function initializeMem0Integration() {
+  addMem0Button();
+  addSyncButton();
+  addEnterKeyInterception();
 
-  observerForEnterKey.observe(document.body, {
-    childList: true,
-    subtree: true,
+  document.addEventListener("keydown", function (event) {
+    if (event.ctrlKey && (event.key === "m" || event.key === "M")) {
+      event.preventDefault();
+      event.stopPropagation();
+      const activeElement = document.activeElement;
+      const inputElement = document.querySelector("textarea#prompt-textarea");
+      if (activeElement === inputElement || (inputElement && inputElement.value.trim() !== "")) {
+         handleMem0Click(true);
+      } else {
+         handleMem0Click(true); // Or some other behavior if input is empty
+      }
+    }
   });
+  observeDOMChanges();
 }
 
 function addEnterKeyInterception() {
-  const inputElement =
-    document.querySelector('div[contenteditable="true"]') ||
-    document.querySelector("textarea");
+  const inputElement = document.querySelector("textarea#prompt-textarea");
 
   if (inputElement && !inputElement.dataset.enterKeyIntercepted) {
-    inputElement.dataset.enterKeyIntercepted = "true";
-
-    inputElement.addEventListener(
-      "keydown",
-      async function (event) {
-        if (event.key === "Enter" && !event.shiftKey) {
-          event.preventDefault();
-          event.stopPropagation();
-
-          const memoryEnabled = await getMemoryEnabledState();
-          if (memoryEnabled) {
-            // Call handleMem0Click
-            handleMem0Click(true)
-              .then(() => {
-                // If you want to submit the message after Mem0 processing:
-                // const sendButton = document.querySelector('button[aria-label="Send prompt"]');
+    chrome.storage.sync.get({ enterKeyInterceptionEnabled: true }, function (data) {
+      if (data.enterKeyInterceptionEnabled) {
+        inputElement.dataset.enterKeyIntercepted = "true";
+        inputElement.addEventListener(
+          "keydown",
+          async function (event) {
+            if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+              const memoryEnabled = await getMemoryEnabledState();
+              const currentInputValue = getInputValue();
+              if (memoryEnabled && currentInputValue && currentInputValue.trim() !== "") {
+                event.preventDefault();
+                event.stopPropagation();
+                try {
+                  await handleMem0Click(true);
+                } catch (error) {
+                  console.error("Error in Mem0 processing on Enter:", error);
+                }
+              } else if (!memoryEnabled && currentInputValue && currentInputValue.trim() !== "") {
+                // Allow default send if memory is disabled but there's text.
+                // Since we preventDefault, we might need to manually trigger send.
+                // For now, this path does nothing, relying on user to click send.
+                // To enable send:
+                // const sendButton = document.querySelector('button[data-testid="send-button"]');
                 // if (sendButton) sendButton.click();
-              })
-              .catch((error) => {
-                console.error("Error in Mem0 processing:", error);
-              });
-          } else {
-            // If memory is disabled, just click the send button
-            const sendButton = document.querySelector(
-              'button[aria-label="Send prompt"]'
-            );
-            if (sendButton) {
-              sendButton.click();
-            } else {
-              console.error("Send button not found");
+              }
             }
-          }
+          },
+          true
+        );
+      } else {
+        if (inputElement.dataset.enterKeyIntercepted) {
+            delete inputElement.dataset.enterKeyIntercepted;
         }
-      },
-      true
-    );
+      }
+    });
   }
 }
 
-// Add this new function to get the memory_enabled state
 function getMemoryEnabledState() {
   return new Promise((resolve) => {
-    chrome.storage.sync.get(["memory_enabled"], function (result) {
-      resolve(result.memory_enabled !== false); // Default to true if not set
+    chrome.storage.sync.get({ memory_enabled: true }, function (result) { // Default true
+      resolve(result.memory_enabled);
     });
   });
 }
 
-initializeMem0Integration();
+// Initialize after DOM is ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeMem0Integration);
+} else {
+  initializeMem0Integration();
+}

--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["icons/*"],
+      "resources": ["icons/*", "sidebar.css"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/sidebar.css
+++ b/sidebar.css
@@ -1,0 +1,549 @@
+#mem0-sidebar {
+  font-family: Arial, sans-serif;
+}
+.fixed-header {
+  position: sticky;
+  top: 0;
+  background-image: url('chrome-extension://__MSG_@@extension_id__/icons/header-bg.png');
+  background-size: cover;
+  background-position: center;
+  z-index: 1000;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 10px 15px 15px;
+  width: 100%
+}
+.logo-container {
+  display: fixed;
+  height: 24px;
+}
+.logo {
+  width: auto;
+  height: 24px;
+}
+.header-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.header-icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  transition: filter 0.3s ease;
+}
+.header-icon-button:hover {
+  filter: brightness(70%);
+}
+.header-icon-button .svg-icon {
+  width: 20px;
+  height: 20px;
+  filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
+}
+.header-icon-button.active {
+  filter: brightness(50%);
+}
+.scroll-area {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 10px;
+  width: 100%;
+}
+.shortcut-info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  padding: 6px;
+  font-size: 12px;
+  color: #666;
+  background-color: #f5f5f5;
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  width: 100%;
+}
+.ellipsis-menu {
+  position: absolute;
+  top: 100%;
+  right: 10px;
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  display: none;
+  z-index: 1001;
+  width: 140px;
+}
+.loading-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+.loader {
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid #3498db;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+.memory-item {
+  display: flex;
+  flex-direction: column;
+  padding: 15px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  background-color: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+.memory-item:hover {
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+.memory-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+.memory-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+
+}
+.memory-text {
+  flex: 1;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  font-size: 14px;
+  margin-right: 10px;
+  color: black;
+}
+.memory-buttons {
+  display: flex;
+  gap: 5px;
+  flex-shrink: 0;
+}
+.memory-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+}
+.memory-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-items: center;
+}
+.category {
+  font-size: 12px;
+  background-color: #f0f0f0;
+  color: #888;
+  padding: 3px 8px;
+  border-radius: 10px;
+  margin-right: 4px;
+}
+.memory-date {
+  font-size: 12px;
+  color: #999;
+  text-align: right;
+  flex-shrink: 0;
+}
+.icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  transition: filter 0.3s ease;
+}
+.icon-button:hover {
+  filter: brightness(70%);
+}
+.icon-button .svg-icon {
+  width: 16px;
+  height: 16px;
+  filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(80%) contrast(100%);
+}
+.icon-button:disabled {
+  cursor: default;
+}
+.memory-text[contenteditable="true"] {
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  outline: none;
+}
+.search-memory {
+  display: flex;
+
+  align-items: center;
+
+  width: 100%;
+  box-sizing: border-box;
+  background-color: transparent;
+}
+
+.search-container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 5px 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.search-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
+}
+
+.search-memory span[contenteditable] {
+  flex: 1;
+  border: none;
+  outline: none;
+  min-height: 16px;
+  color: black;
+  font-size: 14px;
+}
+
+.search-memory span[contenteditable]:empty:before {
+  content: attr(placeholder);
+  color: #999;
+}
+
+#mem0-sidebar {
+  width: 400px !important;
+  min-width: 400px;
+}
+
+.memory-item {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.memory-content {
+  width: 100%;
+}
+
+.memory-text {
+  width: 100%;
+  word-break: break-word;
+}
+
+.add-memory {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  background-color: transparent;
+}
+
+.add-container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 5px 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.add-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
+}
+
+.add-memory span[contenteditable] {
+  flex: 1;
+  border: none;
+  padding: 0;
+  outline: none;
+  min-height: 16px;
+  color: black;
+  font-size: 14px;
+}
+
+.add-memory span[contenteditable]:empty:before {
+  content: attr(placeholder);
+  color: #999;
+}
+
+.memory-item.highlight {
+  background-color: #f0f0f0;
+  transition: background-color 0.5s ease;
+}
+
+.ellipsis-menu {
+  position: absolute;
+  top: 100%;
+  right: 10px;
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  display: none;
+  z-index: 1001;
+  width: 140px;
+}
+
+.ellipsis-menu button {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+}
+
+.ellipsis-menu button:hover {
+  background-color: #f5f5f5;
+}
+
+.input-container {
+  width: 100%;
+  padding: 0px 10px 0px 10px;
+  box-sizing: border-box;
+}
+
+.scroll-area {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 10px;
+  width: 100%;
+}
+
+.search-memory,
+.add-memory {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 15px;
+  padding-right: 5px;
+}
+
+.footer-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 15px;
+  background-color: #f5f5f5;
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 12px;
+  color: #666;
+}
+
+.shortcut-text {
+  flex-grow: 1;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.toggle-text {
+  font-size: 12px;
+  color: #666;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #444; /* Dark gray for "on" state */
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #444;
+}
+
+input:checked + .slider:before {
+  transform: translateX(16px);
+}
+
+.slider.round {
+  border-radius: 20px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
+.provider-icon {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  margin-left: 0;
+  margin-top: 2px;
+}
+
+/* Settings View Styles */
+#mem0-settings-view {
+  color: #333; /* Darker text for readability */
+}
+
+#mem0-settings-view h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+#mem0-settings-view h4 {
+  font-size: 15px;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 5px;
+  font-weight: bold;
+}
+
+.settings-input {
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  flex-grow: 1;
+  margin-right: 5px;
+  box-sizing: border-box;
+}
+
+.settings-button {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f0f0f0;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.settings-button:hover {
+  background-color: #e0e0e0;
+}
+
+#saveApiKeyBtn {
+  background-color: #4CAF50; /* Green */
+  color: white;
+  border-color: #4CAF50;
+}
+#saveApiKeyBtn:hover {
+  background-color: #45a049;
+}
+
+
+.settings-preference-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+}
+
+.settings-preference-item label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  cursor: pointer;
+}
+
+.settings-preference-item span {
+  font-size: 14px;
+}
+
+/* Ensure the switch in settings uses the existing styles if they are global */
+.settings-preference-item .switch {
+  margin-left: 10px; /* Keep the margin from JS if needed */
+}
+
+#settingsStatus {
+  font-size: 12px;
+  color: green;
+  margin-top: 15px;
+  text-align: center;
+  min-height: 18px;
+}
+
+/* Back button in settings - reusing header-icon-button for consistency */
+#backToMemoriesBtn {
+  /* Uses .header-icon-button class from JS */
+  /* Ensure its icon is visible if filter was too dark */
+}
+#backToMemoriesBtn .svg-icon {
+   filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(40%) contrast(100%); /* Adjust if needed */
+}
+#backToMemoriesBtn:hover .svg-icon {
+   filter: brightness(20%);
+}

--- a/sidebar.js
+++ b/sidebar.js
@@ -141,10 +141,20 @@
     ellipsisMenu.id = "ellipsisMenu";
     ellipsisMenu.className = "ellipsis-menu";
     ellipsisMenu.innerHTML = `
+        <button id="settingsBtn">Settings</button>
         <button id="openDashboardBtn">Open Dashboard</button>
         <button id="logoutBtn">Logout</button>
       `;
     fixedHeader.appendChild(ellipsisMenu);
+
+    // Create settings view (initially hidden)
+    const settingsView = document.createElement("div");
+    settingsView.id = "mem0-settings-view";
+    settingsView.style.display = "none"; // Hidden by default
+    settingsView.style.padding = "15px";
+    settingsView.style.width = "100%";
+    settingsView.style.boxSizing = "border-box";
+    // sidebarContainer.appendChild(settingsView); // Will be appended when shown
 
     // Create scroll area with loading indicator
     const scrollArea = document.createElement("div");
@@ -173,6 +183,9 @@
     ellipsisMenuBtn.addEventListener("click", toggleEllipsisMenu);
 
     // Add event listeners for ellipsis menu options
+    const settingsBtn = ellipsisMenu.querySelector("#settingsBtn");
+    settingsBtn.addEventListener("click", showSettingsView);
+
     const openDashboardBtn = ellipsisMenu.querySelector("#openDashboardBtn");
     openDashboardBtn.addEventListener("click", openDashboard);
 
@@ -244,7 +257,11 @@
     });
 
     // Add styles
-    addStyles();
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = chrome.runtime.getURL("sidebar.css");
+    document.head.appendChild(link);
   }
 
   function fetchAndDisplayMemories(newMemory = false) {
@@ -774,470 +791,158 @@
     );
   }
 
-  function addStyles() {
-    const style = document.createElement("style");
-    style.textContent = `
-        #mem0-sidebar {
-          font-family: Arial, sans-serif;
-        }
-        .fixed-header {
-          position: sticky;
-          top: 0;
-          background-image: url('${chrome.runtime.getURL(
-            "icons/header-bg.png"
-          )}');
-          background-size: cover;
-          background-position: center;
-          z-index: 1000;
-          width: 100%;
-          display: flex;
-          flex-direction: column;
-        }
-        .header {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding: 20px 10px 15px 15px;
-          width: 100%
-        }
-        .logo-container {
-          display: fixed;
-          height: 24px;
-        }
-        .logo {
-          width: auto;
-          height: 24px;
-        }
-        .header-buttons {
-          display: flex;
-          gap: 8px;
-          margin-bottom: 4px;
-        }
-        .header-icon-button {
-          background: none;
-          border: none;
-          cursor: pointer;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 24px;
-          height: 24px;
-          transition: filter 0.3s ease;
-        }
-        .header-icon-button:hover {
-          filter: brightness(70%);
-        }
-        .header-icon-button .svg-icon {
-          width: 20px;
-          height: 20px;
-          filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
-        }
-        .header-icon-button.active {
-          filter: brightness(50%);
-        }
-        .scroll-area {
-          flex-grow: 1;
-          overflow-y: auto;
-          padding: 10px;
-          width: 100%;
-        }
-        .shortcut-info {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          gap: 5px;
-          padding: 6px;
-          font-size: 12px;
-          color: #666;
-          background-color: #f5f5f5;
-          position: sticky;
-          bottom: 0;
-          left: 0;
-          right: 0;
-          z-index: 1000;
-          width: 100%;
-        }
-        .ellipsis-menu {
-          position: absolute;
-          top: 100%;
-          right: 10px;
-          background-color: white;
-          border: 1px solid #ccc;
-          border-radius: 4px;
-          box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-          display: none;
-          z-index: 1001;
-          width: 140px;
-        }
-        .loading-indicator {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          height: 100%;
-        }
-        .loader {
-          border: 2px solid #f3f3f3;
-          border-top: 2px solid #3498db;
-          border-radius: 50%;
-          width: 20px;
-          height: 20px;
-          animation: spin 1s linear infinite;
-        }
-        @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
-        .memory-item {
-          display: flex;
-          flex-direction: column;
-          padding: 15px;
-          border: 1px solid #e0e0e0;
-          border-radius: 8px;
-          margin-bottom: 10px;
-          background-color: #ffffff;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-          transition: background-color 0.3s ease, box-shadow 0.3s ease;
-        }
-        .memory-item:hover {
-          box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
-        }
-        .memory-content {
-          display: flex;
-          flex-direction: column;
-          width: 100%;
-        }
-        .memory-top {
-          display: flex;
-          justify-content: space-between;
-          align-items: flex-start;
-          
-        }
-        .memory-text {
-          flex: 1;
-          word-wrap: break-word;
-          white-space: pre-wrap;
-          font-size: 14px;
-          margin-right: 10px;
-          color: black;
-        }
-        .memory-buttons {
-          display: flex;
-          gap: 5px;
-          flex-shrink: 0;
-        }
-        .memory-bottom {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          margin-top: 10px;
-        }
-        .memory-categories {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 5px;
-          align-items: center; // Add this line
-        }
-        .category {
-          font-size: 12px;
-          background-color: #f0f0f0;
-          color: #888;
-          padding: 3px 8px;
-          border-radius: 10px;
-          margin-right: 4px;
-        }
-        .memory-date {
-          font-size: 12px;
-          color: #999;
-          text-align: right;
-          flex-shrink: 0;
-        }
-        .icon-button {
-          background: none;
-          border: none;
-          cursor: pointer;
-          padding: 0;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 20px;
-          height: 20px;
-          transition: filter 0.3s ease;
-        }
-        .icon-button:hover {
-          filter: brightness(70%);
-        }
-        .icon-button .svg-icon {
-          width: 16px;
-          height: 16px;
-          filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(80%) contrast(100%);
-        }
-        .icon-button:disabled {
-          cursor: default;
-        }
-        .memory-text[contenteditable="true"] {
-          padding: 5px;
-          border: 1px solid #ccc;
-          border-radius: 4px;
-          outline: none;
-        }
-        .search-memory {
-          display: flex;
-          
-          align-items: center;
-          
-          width: 100%;
-          box-sizing: border-box;
-          background-color: transparent;
-        }
+  // Add these new functions
 
-        .search-container {
-          display: flex;
-          align-items: center;
-          width: 100%;
-          background-color: #ffffff;
-          border-radius: 20px;
-          padding: 5px 10px;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-        }
+  function showSettingsView() {
+    const sidebarContainer = document.getElementById("mem0-sidebar");
+    const scrollArea = sidebarContainer.querySelector(".scroll-area");
+    const inputContainer = sidebarContainer.querySelector(".input-container");
+    let settingsView = document.getElementById("mem0-settings-view");
 
-        .search-icon {
-          width: 16px;
-          height: 16px;
-          margin-right: 8px;
-          filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
-        }
+    // Hide memories view
+    if (scrollArea) scrollArea.style.display = "none";
+    if (inputContainer) inputContainer.style.display = "none";
+     // Hide ellipsis menu itself when in settings view
+    const ellipsisMenu = document.getElementById("ellipsisMenu");
+    if (ellipsisMenu) ellipsisMenu.style.display = "none";
 
-        .search-memory span[contenteditable] {
-          flex: 1;
-          border: none;
-          outline: none;
-          min-height: 16px;
-          color: black;
-          font-size: 14px;
-        }
 
-        .search-memory span[contenteditable]:empty:before {
-          content: attr(placeholder);
-          color: #999;
-        }
+    if (!settingsView) {
+      settingsView = document.createElement("div");
+      settingsView.id = "mem0-settings-view";
+      settingsView.style.padding = "15px";
+      settingsView.style.width = "100%";
+      settingsView.style.boxSizing = "border-box";
+      settingsView.style.color = "#333"; // Darker text for readability
 
-        #mem0-sidebar {
-          width: 400px !important;
-          min-width: 400px;
-        }
+      settingsView.innerHTML = `
+        <div style="display: flex; align-items: center; margin-bottom: 20px;">
+          <button id="backToMemoriesBtn" class="header-icon-button" style="margin-right: 10px;" title="Back to Memories">
+            <img src="${chrome.runtime.getURL("icons/back-arrow.svg")}" alt="Back" class="svg-icon" style="width: 20px; height: 20px;">
+          </button>
+          <h2 style="margin: 0; font-size: 18px; font-weight: bold;">Settings</h2>
+        </div>
 
-        .memory-item {
-          width: 100%;
-          box-sizing: border-box;
-        }
+        <h4 style="font-size: 15px; margin-top: 20px; margin-bottom: 8px; border-bottom: 1px solid #eee; padding-bottom: 5px;">API Key</h4>
+        <div style="display: flex; align-items: center; margin-bottom: 10px;">
+          <input type="password" id="apiKeyInput" placeholder="Enter your API Key" class="settings-input" style="flex-grow: 1; margin-right: 5px;">
+          <button id="toggleApiKeyVisibilityBtn" class="settings-button" style="margin-right: 5px;">Show</button>
+          <button id="saveApiKeyBtn" class="settings-button">Save</button>
+        </div>
 
-        .memory-content {
-          width: 100%;
-        }
+        <h4 style="font-size: 15px; margin-top: 25px; margin-bottom: 10px; border-bottom: 1px solid #eee; padding-bottom: 5px;">Preferences</h4>
+        <div class="settings-preference-item">
+          <label for="enterKeyToggle" style="display: flex; align-items: center; justify-content: space-between; width: 100%; cursor: pointer;">
+            <span style="font-size: 14px;">Enable Enter-Key for Memory (ChatGPT)</span>
+            <label class="switch" style="margin-left: 10px;">
+              <input type="checkbox" id="enterKeyToggle">
+              <span class="slider round"></span>
+            </label>
+          </label>
+        </div>
+        <p id="settingsStatus" style="font-size: 12px; color: green; margin-top: 15px; text-align: center; min-height: 18px;"></p>
+      `;
+      // Insert settingsView after the fixed-header
+      const fixedHeader = sidebarContainer.querySelector(".fixed-header");
+      if (fixedHeader) {
+        fixedHeader.insertAdjacentElement("afterend", settingsView);
+      } else {
+        sidebarContainer.appendChild(settingsView); // Fallback
+      }
+    }
 
-        .memory-text {
-          width: 100%;
-          word-break: break-word;
-        }
+    settingsView.style.display = "block";
 
-        .add-memory {
-          display: flex;
-          align-items: center;
-          width: 100%;
-          box-sizing: border-box;
-          background-color: transparent;
-        }
+    // Add event listeners
+    document.getElementById("backToMemoriesBtn").addEventListener("click", showMemoriesView);
+    document.getElementById("saveApiKeyBtn").addEventListener("click", saveApiKey);
+    document.getElementById("toggleApiKeyVisibilityBtn").addEventListener("click", toggleApiKeyVisibility);
+    document.getElementById("enterKeyToggle").addEventListener("change", saveEnterKeyPreference);
 
-        .add-container {
-          display: flex;
-          align-items: center;
-          width: 100%;
-          background-color: #ffffff;
-          border-radius: 20px;
-          padding: 5px 10px;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-        }
-
-        .add-icon {
-          width: 16px;
-          height: 16px;
-          margin-right: 8px;
-          filter: invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(60%) contrast(100%);
-        }
-
-        .add-memory span[contenteditable] {
-          flex: 1;
-          border: none;
-          padding: 0;
-          outline: none;
-          min-height: 16px;
-          color: black;
-          font-size: 14px;
-        }
-
-        .add-memory span[contenteditable]:empty:before {
-          content: attr(placeholder);
-          color: #999;
-        }
-
-        .memory-item.highlight {
-          background-color: #f0f0f0;
-          transition: background-color 0.5s ease;
-        }
-
-        .ellipsis-menu {
-          position: absolute;
-          top: 100%;
-          right: 10px;
-          background-color: white;
-          border: 1px solid #ccc;
-          border-radius: 4px;
-          box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-          display: none;
-          z-index: 1001;
-          width: 140px;
-        }
-
-        .ellipsis-menu button {
-          display: block;
-          width: 100%;
-          padding: 8px 12px;
-          text-align: left;
-          background: none;
-          border: none;
-          cursor: pointer;
-          font-size: 14px;
-          color: #333;
-        }
-
-        .ellipsis-menu button:hover {
-          background-color: #f5f5f5;
-        }
-
-        .input-container {
-          width: 100%;
-          padding: 0px 10px 0px 10px;
-          box-sizing: border-box;
-        }
-
-        .scroll-area {
-          flex-grow: 1;
-          overflow-y: auto;
-          padding: 10px;
-          width: 100%;
-        }
-
-        .search-memory,
-        .add-memory {
-          width: 100%;
-          box-sizing: border-box;
-          margin-bottom: 15px;
-          padding-right: 5px;
-        }
-
-        .footer-toggle {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding: 10px 15px;
-          background-color: #f5f5f5;
-          position: sticky;
-          bottom: 0;
-          left: 0;
-          right: 0;
-          z-index: 1000;
-          width: 100%;
-          box-sizing: border-box;
-          font-size: 12px;
-          color: #666;
-        }
-
-        .shortcut-text {
-          flex-grow: 1;
-        }
-
-        .toggle-container {
-          display: flex;
-          align-items: center;
-          gap: 10px;
-        }
-
-        .toggle-text {
-          font-size: 12px;
-          color: #666;
-        }
-
-        .switch {
-          position: relative;
-          display: inline-block;
-          width: 36px;
-          height: 20px;
-        }
-
-        .switch input {
-          opacity: 0;
-          width: 0;
-          height: 0;
-        }
-
-        .slider {
-          position: absolute;
-          cursor: pointer;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 0;
-          background-color: #ccc;
-          transition: .4s;
-        }
-
-        .slider:before {
-          position: absolute;
-          content: "";
-          height: 16px;
-          width: 16px;
-          left: 2px;
-          bottom: 2px;
-          background-color: white;
-          transition: .4s;
-        }
-
-        input:checked + .slider {
-          background-color: #444; /* Dark gray for "on" state */
-        }
-
-        input:focus + .slider {
-          box-shadow: 0 0 1px #444;
-        }
-
-        input:checked + .slider:before {
-          transform: translateX(16px);
-        }
-
-        .slider.round {
-          border-radius: 20px;
-        }
-
-        .slider.round:before {
-          border-radius: 50%;
-        }
-
-        .provider-icon {
-          width: 14px;
-          height: 14px;
-          vertical-align: middle;
-          margin-left: 0;
-          margin-top: 2px;
-        }
-  `;
-    document.head.appendChild(style);
+    // Load current settings values
+    loadSettingsValues();
   }
 
-  // Add these new functions
+  function showMemoriesView() {
+    const sidebarContainer = document.getElementById("mem0-sidebar");
+    const scrollArea = sidebarContainer.querySelector(".scroll-area");
+    const inputContainer = sidebarContainer.querySelector(".input-container");
+    const settingsView = document.getElementById("mem0-settings-view");
+
+    if (settingsView) settingsView.style.display = "none";
+    if (scrollArea) scrollArea.style.display = "block"; // Or "flex" if it's a flex container
+    if (inputContainer) inputContainer.style.display = "block"; // Or "flex"
+
+    fetchAndDisplayMemories(); // Refresh memories
+  }
+
+  function loadSettingsValues() {
+    const apiKeyInput = document.getElementById("apiKeyInput");
+    chrome.storage.sync.get(["apiKey", "enterKeyInterceptionEnabled"], function (data) {
+      if (data.apiKey) {
+        apiKeyInput.value = data.apiKey;
+        // Mask it by default or show last 4 chars:
+        // apiKeyInput.value = "****" + data.apiKey.slice(-4);
+        // For this example, we'll just load it as password type.
+      }
+      const enterKeyToggle = document.getElementById("enterKeyToggle");
+      // Default to true if not set
+      enterKeyToggle.checked = data.enterKeyInterceptionEnabled !== false;
+    });
+  }
+
+  function saveApiKey() {
+    const apiKeyInput = document.getElementById("apiKeyInput");
+    const newApiKey = apiKeyInput.value.trim();
+    const settingsStatus = document.getElementById("settingsStatus");
+
+    if (newApiKey) {
+      chrome.storage.sync.set({ apiKey: newApiKey }, function () {
+        settingsStatus.textContent = "API Key saved successfully!";
+        setTimeout(() => settingsStatus.textContent = "", 3000);
+      });
+    } else {
+      settingsStatus.textContent = "API Key cannot be empty.";
+      settingsStatus.style.color = "red";
+      setTimeout(() => {
+        settingsStatus.textContent = "";
+        settingsStatus.style.color = "green"; // Reset color
+      }, 3000);
+    }
+  }
+
+  function toggleApiKeyVisibility() {
+    const apiKeyInput = document.getElementById("apiKeyInput");
+    const toggleBtn = document.getElementById("toggleApiKeyVisibilityBtn");
+    if (apiKeyInput.type === "password") {
+      apiKeyInput.type = "text";
+      toggleBtn.textContent = "Hide";
+    } else {
+      apiKeyInput.type = "password";
+      toggleBtn.textContent = "Show";
+    }
+  }
+
+  function saveEnterKeyPreference() {
+    const enterKeyToggle = document.getElementById("enterKeyToggle");
+    const settingsStatus = document.getElementById("settingsStatus");
+    chrome.storage.sync.set({ enterKeyInterceptionEnabled: enterKeyToggle.checked }, function () {
+      settingsStatus.textContent = "Preference saved!";
+      setTimeout(() => settingsStatus.textContent = "", 3000);
+    });
+  }
+
+
   function toggleEllipsisMenu(event) {
     event.stopPropagation(); // Prevent the click from bubbling up
     const ellipsisMenu = document.getElementById("ellipsisMenu");
+    // Do not show ellipsis if settings view is active
+    const settingsView = document.getElementById("mem0-settings-view");
+    if (settingsView && settingsView.style.display === "block") {
+      ellipsisMenu.style.display = "none";
+      return;
+    }
+
     ellipsisMenu.style.display =
       ellipsisMenu.style.display === "block" ? "none" : "block";
 
@@ -1245,7 +950,8 @@
     document.addEventListener("click", function closeMenu(e) {
       if (
         !ellipsisMenu.contains(e.target) &&
-        e.target !== document.getElementById("ellipsisMenuBtn")
+        e.target !== document.getElementById("ellipsisMenuBtn") &&
+        (!settingsView || settingsView.style.display === "none") // Also ensure settings isn't blocking this logic
       ) {
         ellipsisMenu.style.display = "none";
         document.removeEventListener("click", closeMenu);


### PR DESCRIPTION
This commit introduces several improvements to the Mem0 Chrome Extension:

1.  **CSS Refactoring:**
    *   Styles for the sidebar (`sidebar.js`) have been moved to a dedicated `sidebar.css` file.
    *   `sidebar.js` now dynamically links this external CSS file.
    *   `manifest.json` updated to include `sidebar.css` in web accessible resources.

2.  **ChatGPT Integration Enhancements (`chatgpt/content.js`):**
    *   Re-implemented a dedicated "Mem0 button" near the ChatGPT input field. This button allows you to manually fetch and inject memories before sending a message.
    *   Improved in-chat feedback using non-intrusive toast notifications for actions like memory injection, no memories found, or errors.
    *   Enter-key interception for memory injection is now optional. A new setting in `chrome.storage.sync` (`enterKeyInterceptionEnabled`, default true) controls this behavior.
    *   Updated DOM selectors for better stability and consolidated MutationObserver logic.

3.  **Sidebar Settings Panel:**
    *   Added a new "Settings" section accessible from the sidebar's ellipsis menu.
    *   You can now view your API key (with a show/hide toggle) and update it directly within the sidebar.
    *   Added a toggle switch in the settings panel to control the "Enable Enter-Key for Memory (ChatGPT)" preference.

4.  **Documentation (README.md):**
    *   Updated to reflect the new Mem0 button in ChatGPT.
    *   Documented the new Settings panel in the sidebar, including API key management and the Enter-key interception toggle.
    *   Added a placeholder note for updating screenshots.

These changes aim to improve your control, provide better feedback, enhance code maintainability, and make the extension more user-friendly.